### PR TITLE
Añadido checkbox al formulario de reporte

### DIFF
--- a/mapa/templates/mapa/reporte_form.html
+++ b/mapa/templates/mapa/reporte_form.html
@@ -23,7 +23,7 @@
                 </div>
 
                 <div class="panel-body">
-                    <form action="" method="post">{% csrf_token %}
+                    <form action="" method="post" onsubmit="if(document.getElementById('agree').checked) { return true; } else { alert('Por favor, para enviar el reporte, indique que ha leído el Aviso Legal y acepta la Política de Privacidad.'); return false; }" >{% csrf_token %}
                         <br style="clear:both">
                         <h3 style="margin-bottom: 25px; text-align: center;">Reportar un problema</h3>
 
@@ -46,6 +46,10 @@
                             <label for="{{ form.descripcion.id_for_label }}">{{ form.descripcion.label }}</label>
                             <label class="has-error">{{ form.tipo.errors }}</label>
                                 {{ form.descripcion|add_class:"form-control"}}
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="checkbox" value="check" id="agree"/>
+                            <label class="form-check-label" for="agree">Acepto el <a href="https://ritsi.org/aviso-legal/">Aviso Legal</a> y la <a href="https://ritsi.org/politica-de-privacidad/">Política de Privacidad</a>.</label>
                         </div>
                         <input id="submit-tasas" class="btn btn-success" type="submit" value="Enviar">
                     </form>


### PR DESCRIPTION
Añadido checkbox al formulario para enviar un reporte en el Mapa de Tasas. En el texto se añaden enlaces al Aviso Legal y a la Política de Privacidad de la asociación.

![imagen](https://user-images.githubusercontent.com/9568287/41987616-fcd0fb3e-7a39-11e8-85f7-4b87447e4f49.png)

En caso de no aceptar el aviso legal, se muestra un aviso pidiendo que se acepten para poder enviar el reporte.

![imagen](https://user-images.githubusercontent.com/9568287/41987636-0892a530-7a3a-11e8-8d22-d3a5af8763e3.png)

El mensaje está incluido en el código html de la página. Un trabajo futuro sería incluir el mensaje en el locale de la página web, como en #44 .